### PR TITLE
Many fixes to live-hwclock

### DIFF
--- a/etc/init.d/live-hwclock
+++ b/etc/init.d/live-hwclock
@@ -56,7 +56,7 @@ do_start() {
    echo_script "$_Configuring_Hardware_Clock_" $0
 
    mountpoint -q /live/aufs || PRETEND_MODE=true
-   [ "$PRETEND_MODE" ] && echo_live "${AMBER}Pretend mode enabled"
+   [ "$PRETEND_MODE" ] && echo_live "${YELLOW}Pretend mode enabled"
 
     case $CMD_CLOCK in
         local|utc) set_hwclock $CMD_CLOCK ;;
@@ -83,7 +83,7 @@ set_hwclock() {
 
 ask_hwclock() {
     local green=$GREEN white=$WHITE cyan=$CYAN nc_co=$NO_COLOR hi_co=$WHITE
-    local bold_co=$AMBER  cheat_co=$WHITE
+    local bold_co=$YELLOW  cheat_co=$WHITE
 
     echo
     check_timezone || return
@@ -101,10 +101,11 @@ check_timezone() {
         yes_no_quit "$LIVE_COLOR$(printf "Is %s your current timezone" "$(pquote $TZ)")"
         local ret=$?
         case $ret in
-             0)  echo "orig: $orig_tz   new: $TZ"
-                 if [ "$orig_tz" != "$TZ" ]; then
+             0) if [ "$orig_tz" != "$TZ" ]; then
                     export TZ
                     pretend write_to_file $TZ_FILE $TZ
+                    # For localizing repos in live-init
+                    pretend append_file /live/config/cmdline "tz=$TZ"
                 fi
                 return 0     ;;
              1) set_timezone ;;
@@ -288,8 +289,8 @@ my_select_menu() {
     [ -z "${menu##*$cheat*}" ] || return
 
     if [ ! -e $dfile -o  ! -e $mfile ]; then
-        [ "$BOOT_MENU_WARN" ] && warn "Missing $dfile or $mfile"
-        return
+        error "$_Missing_dfile_or_mfile_"
+        exit 2
     fi
 
     local menu_value
@@ -372,6 +373,20 @@ show_time() { echo_live "$_X_START_PARAM_Y_" "$1" "$2"; }
 show_unix() { echo_live "$_X_Unix_START_PARAM_Y_" "$1" "$2" ; }
 
 debug() { [ ${#db_hwc} -gt 0 ] && echo "$*"; }
+
+write_to_file() {
+    local file=$1
+    local dir=$(dirname $file)
+    mkdir -p $dir
+    echo -e "$*" > $file
+}
+
+append_file() {
+    local file=$1
+    local dir=$(dirname $file)
+    mkdir -p $dir
+    echo -e "$*" >> $file
+}
 
 pretend() {
     if [ "$PRETEND_MODE" ]; then

--- a/live/locale/xlat/en/live-hwclock.xlat
+++ b/live/locale/xlat/en/live-hwclock.xlat
@@ -4,6 +4,7 @@ _Either_your_timezone_is_incorrect_or_your_hardware_clock_is_incorrect_or_both_=
 _Got_a_strange_answer_from_guess_hwclock_menu_X_="Got a strange answer from guess hwclock menu %s"
 _Help_us_figure_out_what_time_is_used_by_your_hardware_clock_="Help us figure out what time is used by your hardware clock"
 _It_seems_your_hardware_clock_is_not_set_to_local_time_or_to_UTC_time_="It seems your hardware clock is not set to local time or to UTC time."
+_Missing_dfile_or_mfile_="Missing $dfile or $mfile"
 _Please_wait_while_we_examine_the_hardware_clock_="Please wait while we examine the hardware clock ..."
 _Press_enter_to_continue_="Press <enter> to continue"
 _They_both_say_the_current_time_is_X_="They both say the current time is %s"


### PR DESCRIPTION
I fixed things as I prepared the tarball to post on the MX forums.

```
Add write_to_file() and append_file() to work with pretend()
The simple "pretend" function can't handle redirects (>, >>).

Create an error if the timezone menu/data files are missing

Append new timezone to /live/config/cmdline
So live-init will use it for localize-repo.  If we don't do this
then the new timezone selected by live-hwclock won't be used
for localize-repo.

Change AMBER to YELLOW
```
